### PR TITLE
moved to local .env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ public
 .DS_Store
 coverage
 config.js
+.env

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "chalk": "^1.0.0",
     "connect-mongo": "^0.7.0",
     "cookie-parser": "^1.3.4",
+    "dotenv": "^1.2.0",
     "express": "^4.12.0",
     "express-session": "^1.10.3",
     "gulp": "^3.8.11",

--- a/server/app/configure/app-variables.js
+++ b/server/app/configure/app-variables.js
@@ -7,7 +7,7 @@ var rootPath = path.join(__dirname, '../../../');
 var indexPath = path.join(rootPath, './server/app/views/index.html');
 var faviconPath = path.join(rootPath, './server/app/views/favicon.ico');
 
-var env = require(path.join(rootPath, './server/env'));
+// var env = require(path.join(rootPath, './server/env'));
 
 var logMiddleware = function (req, res, next) {
     util.log(('---NEW REQUEST---'));
@@ -18,7 +18,7 @@ var logMiddleware = function (req, res, next) {
 };
 
 module.exports = function (app) {
-    app.setValue('env', env);
+    // app.setValue('env', env);
     app.setValue('projectRoot', rootPath);
     app.setValue('indexHTMLPath', indexPath);
     app.setValue('faviconPath', faviconPath);

--- a/server/app/configure/authentication/index.js
+++ b/server/app/configure/authentication/index.js
@@ -20,7 +20,8 @@ module.exports = function (app) {
     // Our sessions will get stored in Mongo using the same connection from
     // mongoose. Check out the sessions collection in your MongoCLI.
     app.use(session({
-        secret: app.getValue('env').SESSION_SECRET,
+        // secret: app.getValue('env').SESSION_SECRET,
+        secret: process.env.SESSION_SECRET,
         store: new MongoStore({mongooseConnection: mongoose.connection}),
         resave: false,
         saveUninitialized: false

--- a/server/db/index.js
+++ b/server/db/index.js
@@ -3,7 +3,8 @@ var Promise = require('bluebird');
 var path = require('path');
 var chalk = require('chalk');
 
-var DATABASE_URI = require(path.join(__dirname, '../env')).DATABASE_URI;
+// var DATABASE_URI = require(path.join(__dirname, '../env')).DATABASE_URI;
+var DATABASE_URI = process.env.MONGOURI;
 
 var mongoose = require('mongoose');
 var db = mongoose.connect(DATABASE_URI).connection;

--- a/server/start.js
+++ b/server/start.js
@@ -12,5 +12,6 @@
 
 */
 
+require('dotenv').load();
 require('babel/register');
 require('./main');


### PR DESCRIPTION
I decided to use the dotenv package. this way, we can set local process.env variables (in a .env file that is excluded from the git repo). so in our code, we don't need to say 
if(process.env.NODE_ENV == 'production) { 
   // do stuff
} else {
   // do other stuff
}

we can just say process.env.VARIABLE and set VARIABLE in the .env file! way easier!

with this we can probably delete the /server/env directory all together, but one step at a time...
